### PR TITLE
Replace removed "Triangle" icon (U+F909) with (U+F040A)

### DIFF
--- a/lib/icons.nix
+++ b/lib/icons.nix
@@ -130,7 +130,7 @@
     Telescope = "";
     Text = "";
     Tree = "";
-    Triangle = "契";
+    Triangle = "󰐊";
     TriangleShortArrowDown = "";
     TriangleShortArrowLeft = "";
     TriangleShortArrowRight = "";


### PR DESCRIPTION
*not sure if it's mentioned anywhere, but I assume this repo is intended to be used with nerd fonts?*

`nf-mdi-play` (U+F909) was removed from nerd fonts at some point and now (depending on system fonts) shows a Chinese character.

As far as I can tell, `nf-md-play` (U+F040A) is the same icon, just with a unicode character that doesn't overlap?